### PR TITLE
Error during make Checks and tests

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1614,6 +1614,7 @@ function start-kube-apiserver {
   params+=" --service-account-issuer=${SERVICEACCOUNT_ISSUER}"
   params+=" --service-account-api-audiences=${SERVICEACCOUNT_ISSUER}"
   params+=" --service-account-signing-key-file=${SERVICEACCOUNT_KEY_PATH}"
+  params+=" --encryption-provider-config=${ENCRYPTION_PROVIDER_CONFIG_PATH}"
 
   local audit_policy_config_mount=""
   local audit_policy_config_volume=""
@@ -1869,7 +1870,7 @@ function start-kube-apiserver {
 # ENCRYPTION_PROVIDER_CONFIG_PATH (will default to /etc/srv/kubernetes/encryption-provider-config.yml)
 function setup-etcd-encryption {
   local kube_apiserver_template_path
-  local -n kube_api_server_params
+  local kube_api_server_params
   local default_encryption_provider_config_vol
   local default_encryption_provider_config_vol_mnt
   local encryption_provider_config_vol_mnt


### PR DESCRIPTION
Below Error are seen during make check and test . 
----------------------------------------------------------------------------------------------------------------------------------------------
ion.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,scheduling.k8s.io/v1alpha1,scheduling.k8s.io/v1beta1,settings.k8s.io/v1alpha1,storage.k8s.io/v1beta1,storage.k8s.io/v1,storage.k8s.io/v1alpha1,
+++ [0129 16:47:18] Running tests without code coverage
--- FAIL: TestEncryptionProviderFlag (0.23s)
    --- FAIL: TestEncryptionProviderFlag/ENCRYPTION_PROVIDER_CONFIG_is_set (0.10s)
        configure_helper_test.go:133: Start kubernetes api-server
            ./configure-helper.sh: line 1872: local: -n: invalid option
            local: usage: local [option] name[=value] ...
        configure_helper_test.go:134: Failed to run configure-helper.sh: exit status 2

----------------------------------------------------------------------------------------------------------------------------------------------

FAIL    k8s.io/kubernetes/cluster/gce/gci       1.353s
--- FAIL: TestEncryptionProviderFlag (0.52s)
    --- FAIL: TestEncryptionProviderFlag/ENCRYPTION_PROVIDER_CONFIG_is_set (0.29s)
        configure_helper_test.go:136: Start kubernetes api-server
        apiserver_manifest_test.go:140: Got "exec /usr/local/bin/kube-apiserver --v=2  --cloud-config=/etc/gce.conf --address=127.0.0.1 --allow-privileged=true --cloud-provider=gce --client-ca-file=/foo/bar --etcd-servers=http://127.0.0.1:2379 --etcd-servers-overrides=/events#http://127.0.0.1:4002 --secure-port=443 --tls-cert-file=/foo/bar --tls-private-key-file=/foo/bar --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --enable-aggregator-routing=true --token-auth-file=/etc/srv/kubernetes/known_tokens.csv --service-account-issuer=https://foo.bar.baz --service-account-api-audiences=https://foo.bar.baz --service-account-signing-key-file=/foo/bar/baz.key --authorization-mode=Node,RBAC --allow-privileged=true 1>>/var/log/kube-apiserver.log 2>&1",
             want flags to contain "--encryption-provider-config=/tmp/configure-helper-test420478490/encryption-provider-config.yaml"
----------------------------------------------------------------------------------------------------------------------------------------------

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
